### PR TITLE
Support second argument to #respond_to?

### DIFF
--- a/lib/future.rb
+++ b/lib/future.rb
@@ -36,8 +36,8 @@ class Future < defined?(BasicObject) ? BasicObject : Object
   #
   # @param  [Symbol]
   # @return [Boolean]
-  def respond_to?(method)
-    :force.equal?(method) || :__force__.equal?(method) || __force__.respond_to?(method)
+  def respond_to?(method, include_all=false)
+    :force.equal?(method) || :__force__.equal?(method) || __force__.respond_to?(method, include_all)
   end
 
   private

--- a/lib/promise.rb
+++ b/lib/promise.rb
@@ -59,10 +59,10 @@ class Promise < defined?(BasicObject) ? BasicObject : ::Object
   ##
   # Does this promise support the given method?
   #
-  # @param  [Symbol]
+  # @param  [Symbol, Boolean]
   # @return [Boolean]
-  def respond_to?(method)
-    :force.equal?(method) || :__force__.equal?(method) || __force__.respond_to?(method)
+  def respond_to?(method, include_all=false)
+    :force.equal?(method) || :__force__.equal?(method) || __force__.respond_to?(method, include_all)
   end
 
   private


### PR DESCRIPTION
This matches Object's interface in Ruby 1.8.7--2.1.1 (at least), and avoids a
warning that our #respond_to? "is old fashion which takes only one parameter".
