### PR TITLE
Make force work in conditions for futures, not only promises.

### DIFF
--- a/lib/future.rb
+++ b/lib/future.rb
@@ -27,7 +27,7 @@ class Future < defined?(BasicObject) ? BasicObject : Object
   # @return [Object]
   def __force__
     @thread.join if @thread
-    @promise
+    @promise.__force__
   end
   alias_method :force, :__force__
 

--- a/spec/promise_spec.rb
+++ b/spec/promise_spec.rb
@@ -33,6 +33,18 @@ describe Promise do
     expect {x = [ 1, @method.call { x / 0 }]}.to_not raise_error
   end
 
+  describe 'compatibility with Marshal' do
+    it 'should not respond_to? marshal_dump' do
+      x = @method.call { 3 + 5 }
+      expect(x).to_not respond_to(:marshal_dump)
+    end
+
+    it 'should respond_to? _dump' do
+      x = @method.call { 3 + 5 }
+      expect(x).to respond_to(:_dump)
+    end
+  end
+
   describe 'an object referencing a promise' do
     class ClassResulting
       attr_reader :value

--- a/spec/shared_promise.rb
+++ b/spec/shared_promise.rb
@@ -143,15 +143,4 @@ shared_examples_for "A Promise" do
     expect(changeds.size).to eq 10
   end
 
-  describe 'compatibility with Marshal' do
-    it 'should not respond_to? marshal_dump' do
-      x = @method.call { 3 + 5 }
-      expect(x).to_not respond_to(:marshal_dump)
-    end
-
-    it 'should respond_to? _dump' do
-      x = @method.call { 3 + 5 }
-      expect(x).to respond_to(:_dump)
-    end
-  end
 end

--- a/spec/shared_promise.rb
+++ b/spec/shared_promise.rb
@@ -21,6 +21,20 @@ shared_examples_for "A Promise" do
     expect(x).to eq 8
   end
 
+  it "should work in conditions (at least when forced)" do
+    for value in [true, false, nil, 1, "test", [], {}, Object.new]
+      result = (value if value)
+      x = @method.call { value }
+      expect(x.__force__).to eq value
+      expect(x).to eq value
+      expect((value if x.__force__)).to eq result
+      # Unfortunately this can't be done:
+      # expect((value if x)).to eq result
+      # The promise/future itself is always not nil, so we get this instead:
+      expect((value if x)).to eq value
+    end
+  end
+
   it "should respond_to? force" do
     x = @method.call { 3 + 5 }
     expect(x).to respond_to(:force)


### PR DESCRIPTION
The Future#**force** should return the resulting value, not the promise. Otherwise things like

``` ruby
   puts "true" if future{ true }.force
   puts "false" if future{ false }.force
   puts "nil" if future{ nil }.force
```

do not work as expected (currently all evaluate to true). I believe it should work consistently with promises:

``` ruby
   puts "true" if promise{ true }.force
   puts "false" if promise{ false }.force
   puts "nil" if promise{ nil }.force
```

The change above should achieve this. However note it may change how the marshalling works with regard to futures, as the special marshalling handling found in Promise becomes bypassed. You may want to review this aspect yourself.
